### PR TITLE
Use file system events instead of polling.

### DIFF
--- a/lib/livereload.coffee
+++ b/lib/livereload.coffee
@@ -84,9 +84,8 @@ class Server
   watch: (dirname) ->
     @walkTree dirname, (err, filename) =>
       throw err if err
-      fs.watchFile filename, (curr, prev) =>
-        if curr.mtime > prev.mtime
-          @refresh filename
+      fs.watch filename, (event, fname) =>
+        @refresh filename
 
   refresh: (path) ->
     @debug "Refresh: #{path}"
@@ -97,7 +96,10 @@ class Server
     ]
 
     for socket in @sockets
-      socket.send data
+      try
+        socket.send data
+      catch  # ignore socket errors and keep going...
+        null
 
   debug: (str) ->
     if @config.debug

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -123,10 +123,8 @@
         if (err) {
           throw err;
         }
-        return fs.watchFile(filename, function(curr, prev) {
-          if (curr.mtime > prev.mtime) {
-            return _this.refresh(filename);
-          }
+        return fs.watch(filename, function(event, fname) {
+          return _this.refresh(filename);
         });
       });
     };
@@ -145,7 +143,11 @@
       _results = [];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         socket = _ref[_i];
-        _results.push(socket.send(data));
+        try {
+          _results.push(socket.send(data));
+        } catch (_error) {
+          _results.push(null);
+        }
       }
       return _results;
     };


### PR DESCRIPTION
**Warning!** This is the first of two conflicting pull requests. There are three options:
1. Merge only this pull request. File system events are less laggy and use less CPU, but they did introduce socket errors (which I worked-around) and may introduce compatibility issues with other systems/older versions of Node.js.
2. Merge only the other pull request. A safer, more conservative change that removes most of the delay at the cost of extra CPU.
3. Support both file system events and polling by adding an option and combining these two pull requests. Shouldn't be that hard.

<hr />

_Commit message:_

Replace fs.watchFile with fs.watch.
Best of both worlds: minimal lag and minimal CPU usage!

Socket errors started being thrown; wrapped and ignored with try block.
Does not seem to affect live browser reload.
