### PR TITLE
Eliminate agonizing delay until browser reload.

### DIFF
--- a/lib/livereload.coffee
+++ b/lib/livereload.coffee
@@ -84,7 +84,7 @@ class Server
   watch: (dirname) ->
     @walkTree dirname, (err, filename) =>
       throw err if err
-      fs.watchFile filename, (curr, prev) =>
+      fs.watchFile filename, {interval:1000}, (curr, prev) =>
         if curr.mtime > prev.mtime
           @refresh filename
 

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -123,7 +123,9 @@
         if (err) {
           throw err;
         }
-        return fs.watchFile(filename, function(curr, prev) {
+        return fs.watchFile(filename, {
+          interval: 1000
+        }, function(curr, prev) {
           if (curr.mtime > prev.mtime) {
             return _this.refresh(filename);
           }


### PR DESCRIPTION
**Warning!** This is the second of two conflicting pull requests. There are three options:
1. Merge only the other pull request. File system events are less laggy and use less CPU, but they did introduce socket errors (which I worked-around) and may introduce compatibility issues with other systems/older versions of Node.js.
2. Merge only this pull request. A safer, more conservative change that removes most of the delay at the cost of extra CPU.
3. Support both file system events and polling by adding an option and combining these two pull requests. Shouldn't be that hard.

<hr />

_Commit message:_

Call fs.watchFile() with interval option.
1000ms selected to balance decreased lag with increased CPU usage.
(~10% CPU usage when serving site with 9477 files, 4049 folders).
