### PR TITLE
Use wss:// when served from https://

### DIFF
--- a/ext/livereload.js
+++ b/ext/livereload.js
@@ -137,11 +137,13 @@ __connector.Connector = Connector = (function() {
 
   function Connector(options, WebSocket, Timer, handlers) {
     var _this = this;
+    var webSocketProtocol;
     this.options = options;
     this.WebSocket = WebSocket;
     this.Timer = Timer;
     this.handlers = handlers;
-    this._uri = "ws://" + this.options.host + ":" + this.options.port + "/livereload";
+    webSocketProtocol = document.location.protocol === "https:" ? "wss:" : "ws:";
+    this._uri = "" + webSocketProtocol + "//" + this.options.host + ":" + this.options.port + "/livereload";
     this._nextDelay = this.options.mindelay;
     this._connectionDesired = false;
     this.protocol = 0;


### PR DESCRIPTION
When the page is served via `https`, also request the WebSocket via SSL.

Note that the syntax style I used is because of how CoffeeScript is compiled into JS. Keeping it this way here, helps with any future merge with `livereload.js` from the upstream [livereload-js](https://github.com/livereload/livereload-js/) project.
