### PR TITLE
FIX for legacy-cased “stylesheet” RELs

### DIFF
--- a/ext/livereload.js
+++ b/ext/livereload.js
@@ -603,7 +603,7 @@ Options.extract = function(document) {
         _results = [];
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           link = _ref[_i];
-          if (link.rel === 'stylesheet' && !link.__LiveReload_pendingRemoval) {
+          if (link.rel.match(/^stylesheet$/i) && !link.__LiveReload_pendingRemoval) {
             _results.push(link);
           }
         }
@@ -1010,7 +1010,7 @@ __less = LessPlugin = (function() {
       _results = [];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         link = _ref[_i];
-        if (link.href && link.rel === 'stylesheet/less' || (link.rel.match(/stylesheet/) && link.type.match(/^text\/(x-)?less$/))) {
+        if (link.href && link.rel.match(/^stylesheet\/less$/i) || (link.rel.match(/stylesheet/i) && link.type.match(/^text\/(x-)?less$/i))) {
           _results.push(link);
         }
       }


### PR DESCRIPTION
Livereload fails to properly compare URLs when LINKs are served with differently-cased RELL attributes.
Already fixed for https://github.com/guard/guard-livereload/issues/118, but made it more elegant 2nd time around...