### PR TITLE
Add 'wait' to server options

### DIFF
--- a/lib/livereload.coffee
+++ b/lib/livereload.coffee
@@ -38,6 +38,9 @@ class Server
 
     @config.usePolling ?= false
 
+    @config.wait ?= 0
+    @config.delay = @config.wait
+
   listen: ->
     @debug "LiveReload is waiting for browser to connect."
 

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -26,7 +26,7 @@
 
   Server = (function() {
     function Server(config1) {
-      var base, base1, base2, base3, base4, base5, base6, base7, base8, base9;
+      var base, base1, base10, base2, base3, base4, base5, base6, base7, base8, base9;
       this.config = config1;
       if (this.config == null) {
         this.config = {};
@@ -63,6 +63,10 @@
       if ((base9 = this.config).usePolling == null) {
         base9.usePolling = false;
       }
+      if ((base10 = this.config).wait == null) {
+        base10.wait = 0;
+      }
+      this.config.delay = this.config.wait;
     }
 
     Server.prototype.listen = function() {


### PR DESCRIPTION
In the file **server.js**, the option `wait` don't work

```js
var server = livereload.createServer({
    wait: 3000
});
```

Instead I used the option `delay` to make it work.