### PR TITLE
Added 'ignoreExts' argument for node implementation

### DIFF
--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -26,7 +26,7 @@
 
   Server = (function() {
     function Server(config1) {
-      var base, base1, base2, base3, base4, base5, base6, base7, base8, base9;
+      var base, base1, base2, base3, base4, base5, base6, base7, base8, base9, base10;
       this.config = config1;
       if (this.config == null) {
         this.config = {};
@@ -43,8 +43,13 @@
       if ((base3 = this.config).exclusions == null) {
         base3.exclusions = [];
       }
-      this.config.exts = this.config.exts.concat(defaultExts);
+      if ((base10 = this.config).ignoreExts == null) {
+        base10.ignoreExts = [];
+      }
+
+      this.config.exts = this.config.exts.concat( defaultExts.filter( ext => base10.ignoreExts.find( ignoreExt => new RegExp( ext ).test(ignoreExt) ) === undefined ) )
       this.config.exclusions = this.config.exclusions.concat(defaultExclusions);
+
       if ((base4 = this.config).applyJSLive == null) {
         base4.applyJSLive = false;
       }


### PR DESCRIPTION
So that one could ignore .js, .css file changes to only track .gz files.

```
server = require('livereload').createServer( {
    exts: [ 'gz' ],
    ignoreExts: [ 'js', 'css' ],
    https: { key: fs.readFileSync( process.env.SSLKEY ), cert: fs.readFileSync( process.env.SSLCERT ) },
    originalPath: `https://${process.env.DOMAIN}.com`
} )
```

What do you think?  I am happy to work on this with you further.