### PR TITLE
add config.noListen to stop server auto-listen (fixes #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The `createServer()` method supports a few basic options, passed as a JavaScript
 * `overrideURL` lets you specify a different host for CSS files. This lets you edit local CSS files but view a live site. See <http://feedback.livereload.com/knowledgebase/articles/86220-preview-css-changes-against-a-live-site-then-uplo> for details.
 * `usePolling` Poll for file system changes. Set this to true to successfully watch files over a network.
 * `delay` add a delay (in miliseconds) between when livereload detects a change to the filesystem and when it notifies the browser. Useful if the browser is reloading/refreshing before a file has been compiled, for example, by browserify.
-
+* `noListen` Pass as `true` to indicate that the websocker server should not be started automatically. (useful if you want to start it yourself later)
 
 
 # License

--- a/lib/livereload.coffee
+++ b/lib/livereload.coffee
@@ -135,5 +135,6 @@ exports.createServer = (config = {}) ->
   config.server ?= app
 
   server = new Server config
-  server.listen()
+  unless config.noListen
+    server.listen()
   server

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -194,7 +194,9 @@
       config.server = app;
     }
     server = new Server(config);
-    server.listen();
+    if (!config.noListen) {
+      server.listen();
+    }
     return server;
   };
 


### PR DESCRIPTION
This is my proposal for #74, which adds an extra (optional) `config.noListen` which returns the `Server` that is not automatically listening/started.

I'm creating a web server that also will include a livereload server, and my hope is to initialize them both together, and then expose a single `.listen()` method which will start both up when I'm ready.