### PR TITLE
add callback param that runs when server is ready (fixes #75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ The `createServer()` method supports a few basic options, passed as a JavaScript
 * `overrideURL` lets you specify a different host for CSS files. This lets you edit local CSS files but view a live site. See <http://feedback.livereload.com/knowledgebase/articles/86220-preview-css-changes-against-a-live-site-then-uplo> for details.
 * `usePolling` Poll for file system changes. Set this to true to successfully watch files over a network.
 * `delay` add a delay (in miliseconds) between when livereload detects a change to the filesystem and when it notifies the browser. Useful if the browser is reloading/refreshing before a file has been compiled, for example, by browserify.
-* `noListen` Pass as `true` to indicate that the websocker server should not be started automatically. (useful if you want to start it yourself later)
+* `noListen` Pass as `true` to indicate that the websocket server should not be started automatically. (useful if you want to start it yourself later)
+
+The 2nd argument is an optional `callback` that will be sent to the websocket Server and called for the `listening` event. (ie: when the server is ready to start accepting connections)
 
 
 # License

--- a/lib/livereload.coffee
+++ b/lib/livereload.coffee
@@ -43,12 +43,14 @@ class Server
 
     if @config.server
       @config.server.listen @config.port
-      @server = new ws.Server({server: @config.server}, callback)
+      @server = new ws.Server({server: @config.server})
     else
-      @server = new ws.Server({port: @config.port}, callback)
+      @server = new ws.Server({port: @config.port})
 
     @server.on 'connection', @onConnection.bind @
     @server.on 'close',      @onClose.bind @
+    if callback
+      @server.once 'listening', callback
 
   onConnection: (socket) ->
     @debug "Browser connected."

--- a/lib/livereload.coffee
+++ b/lib/livereload.coffee
@@ -38,14 +38,14 @@ class Server
 
     @config.usePolling ?= false
 
-  listen: ->
+  listen: (callback) ->
     @debug "LiveReload is waiting for browser to connect."
 
     if @config.server
       @config.server.listen @config.port
-      @server = new ws.Server({server: @config.server})
+      @server = new ws.Server({server: @config.server}, callback)
     else
-      @server = new ws.Server({port: @config.port})
+      @server = new ws.Server({port: @config.port}, callback)
 
     @server.on 'connection', @onConnection.bind @
     @server.on 'close',      @onClose.bind @
@@ -122,7 +122,7 @@ class Server
     @server._server.close()
     @server.close()
 
-exports.createServer = (config = {}) ->
+exports.createServer = (config = {}, callback) ->
   requestHandler = ( req, res )->
     if url.parse(req.url).pathname is '/livereload.js'
       res.writeHead(200, {'Content-Type': 'text/javascript'})
@@ -136,5 +136,5 @@ exports.createServer = (config = {}) ->
 
   server = new Server config
   unless config.noListen
-    server.listen()
+    server.listen(callback)
   server

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -65,7 +65,7 @@
       }
     }
 
-    Server.prototype.listen = function() {
+    Server.prototype.listen = function(callback) {
       this.debug("LiveReload is waiting for browser to connect.");
       if (this.config.server) {
         this.config.server.listen(this.config.port);
@@ -78,7 +78,10 @@
         });
       }
       this.server.on('connection', this.onConnection.bind(this));
-      return this.server.on('close', this.onClose.bind(this));
+      this.server.on('close', this.onClose.bind(this));
+      if (callback) {
+        return this.server.once('listening', callback);
+      }
     };
 
     Server.prototype.onConnection = function(socket) {
@@ -172,7 +175,7 @@
 
   })();
 
-  exports.createServer = function(config) {
+  exports.createServer = function(config, callback) {
     var app, requestHandler, server;
     if (config == null) {
       config = {};
@@ -195,7 +198,7 @@
     }
     server = new Server(config);
     if (!config.noListen) {
-      server.listen();
+      server.listen(callback);
     }
     return server;
   };

--- a/test/index.test.coffee
+++ b/test/index.test.coffee
@@ -75,6 +75,11 @@ describe 'livereload http file serving', ->
 
       done()
 
+  it 'should support passing a callback to the websocket server', (done) ->
+    server = livereload.createServer {port: 35729}, ->
+      server.config.server.close()
+      done()
+
 describe 'livereload file watching', ->
   describe "config.delay", ->
     tmpFile = tmpFile2 = clock = server = refresh = undefined


### PR DESCRIPTION
This addresses #75 by utilizing the existing `callback` param accepted by `ws.Server`. It allows me to add a callback that will fire when the server is truly ready and accepting connections. (useful for logging)