### PR TITLE
Option to reload script tags (default=false).

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The first are some configuration options, passed as a JavaScript object:
 * `extraExts` is an array of extensions you want to observe. The default extensions are `[`html`, `css`, `js`, `png`, `gif`, `jpg`, `php`, `php5`, `py`, `rb`,  `erb`, `coffee`]`.
 * `applyCSSLive` tells LiveReload to reload CSS files in the background instead of refreshing the page. The default for this is `true`.
 * `applyImgLive` tells LiveReload to reload image files in the background instead of refreshing the page. The default for this is `true`. Namely for these extensions: jpg, jpeg, png, gif
+* `applyScriptLive` tells LiveReload to reload script files in the background instead of refreshing the page. The default for this is `false`. Namely for these extensions: js
 * `exclusions` lets you specify files to ignore. By default, this includes `.git/`, `.svn/`, and `.hg/`
 * `originalPath` Set URL you use for development, e.g 'http:/domain.com', then LiveReload will proxy this url to local path.
 * `overrideURL` lets you specify a different host for CSS files. This lets you edit local CSS files but view a live site. See <http://feedback.livereload.com/knowledgebase/articles/86220-preview-css-changes-against-a-live-site-then-uplo> for details.

--- a/ext/livereload.js
+++ b/ext/livereload.js
@@ -1089,6 +1089,7 @@ class LiveReload {
     return this.reloader.reload(message.path, {
       liveCSS: message.liveCSS != null ? message.liveCSS : true,
       liveImg: message.liveImg != null ? message.liveImg : true,
+      liveScript: message.liveScript != null ? message.liveScript : false,
       reloadMissingCSS: message.reloadMissingCSS != null ? message.reloadMissingCSS : true,
       originalPath: message.originalPath || '',
       overrideURL: message.overrideURL || '',
@@ -1506,6 +1507,11 @@ class Reloader {
       return;
     }
 
+    if (options.liveScript && path.match(/\.(js)$/i)) {
+      this.reloadScripts(path);
+      return;
+    }
+
     if (options.isChromeExtension) {
       this.reloadChromeExtension();
       return;
@@ -1597,6 +1603,22 @@ class Reloader {
         if (newValue !== value) {
           style[styleName] = newValue;
         }
+      }
+    }
+  }
+
+  reloadScripts(path) {
+    let script;
+    const expando = this.generateUniqueString();
+
+    for (script of Array.from(this.document.scripts)) {
+      var src = script.src;
+      if (pathsMatch(path, pathFromUrl(src))) {
+        script.parentElement.removeChild(script);
+        var head = document.getElementsByTagName('head')[0];
+        script = document.createElement('script');
+        script.src = this.generateCacheBustUrl(src, expando);;
+        head.appendChild(script);
       }
     }
   }

--- a/lib/livereload.coffee
+++ b/lib/livereload.coffee
@@ -149,6 +149,7 @@ class Server extends EventEmitter
       path: filepath,
       liveCSS: @config.applyCSSLive,
       liveImg: @config.applyImgLive,
+      liveScript: @config.applyScriptLive,
       originalPath: this.config.originalPath,
       overrideURL: this.config.overrideURL
     }

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -169,6 +169,7 @@
         path: filepath,
         liveCSS: this.config.applyCSSLive,
         liveImg: this.config.applyImgLive,
+        liveScript: this.config.applyScriptLive,
         originalPath: this.config.originalPath,
         overrideURL: this.config.overrideURL
       });


### PR DESCRIPTION
Use `{applyScriptLive: true}` in server options to enable.