### PR TITLE
Fix sockets foreach, sending messages to clients

### DIFF
--- a/lib/livereload.coffee
+++ b/lib/livereload.coffee
@@ -163,7 +163,7 @@ class Server extends EventEmitter
     @sendAllClients data
 
   sendAllClients: (data) ->
-    for socket in @server.clients
+    @server.clients.forEach (socket) =>
       socket.send data, (error) =>
         if error
           @debug error

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -186,20 +186,15 @@
     };
 
     Server.prototype.sendAllClients = function(data) {
-      var i, len, ref, results, socket;
-      ref = this.server.clients;
-      results = [];
-      for (i = 0, len = ref.length; i < len; i++) {
-        socket = ref[i];
-        results.push(socket.send(data, (function(_this) {
-          return function(error) {
+      return this.server.clients.forEach((function(_this) {
+        return function(socket) {
+          return socket.send(data, function(error) {
             if (error) {
               return _this.debug(error);
             }
-          };
-        })(this)));
-      }
-      return results;
+          });
+        };
+      })(this));
     };
 
     Server.prototype.debug = function(str) {


### PR DESCRIPTION
PR fixes issue: https://github.com/napcs/node-livereload/issues/135

It was trying to:
```javascript
ref = this.server.clients;
for (i = 0, len = ref.length; i < len; i++) {
```
And as this.server.clients is `new Set`, where `.length` is `undefined`, it did nothing.

Fixed with `.forEach`, works ok now.

Fix is compiled from coffee, so it's ready to merge.
