### PR TITLE
Use `require.resolve` to reliably resolve livereload-js location

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can then start up the server which will listen on port `3000`.
 
 ### Server API
 
-The `createServer()` method accepts two arguments. 
+The `createServer()` method accepts two arguments.
 
 The first are some configuration options, passed as a JavaScript object:
 
@@ -172,11 +172,14 @@ When `/User/Workspace/test/css/style.css` is modified, the stylesheet will be re
 
 # Changelog
 
+### Unreleased
+* Use `require.resolve` to reliably resolve livereload-js location.
+
 ### 0.9.0
 * Serve Livereload client library from an NPM dependency instead of copying the code into the project - smhg
 * Update Chokidar to 3.3.0 which improves performance and reduces CPU load.
 
-### 0.8.2 
+### 0.8.2
 * Fix regression in 0.8.1 where broadcasting failed due to incompatibility between arrays and sets
 * Add debug message when broadcasting to each socket
 * Add debug message for the `input` message from clients
@@ -191,7 +194,7 @@ When `/User/Workspace/test/css/style.css` is modified, the stylesheet will be re
 ### 0.7.0
 * Updates bundled Livereload.js file to v2.3.0 to fix console error.
 * BREAKING CHANGE: The `exts` and `e` options now **replace** the default extensions.
-* Adds the `extraExts` and `ee` options to preserve the old behavior of adding extensions to watch. 
+* Adds the `extraExts` and `ee` options to preserve the old behavior of adding extensions to watch.
 * You can now use `server.on 'error'` in your code to catch the "port in use" message gracefully. The CLI now handles this nicely as well.
 
 ### 0.6.3
@@ -210,7 +213,7 @@ When `/User/Workspace/test/css/style.css` is modified, the stylesheet will be re
 * Fix default exclusions regex
 
 ### 0.6.0
-* Implements LiveReload protocol v7 so browser plugins work again. 
+* Implements LiveReload protocol v7 so browser plugins work again.
 * Removes support for protocol v6
 * Introduces `noListen` option
 * Introduces optional callback which will be invoked when the LiveReload server is listening

--- a/lib/livereload.coffee
+++ b/lib/livereload.coffee
@@ -190,7 +190,7 @@ exports.createServer = (config = {}, callback) ->
   requestHandler = ( req, res )->
     if url.parse(req.url).pathname is '/livereload.js'
       res.writeHead(200, {'Content-Type': 'text/javascript'})
-      res.end fs.readFileSync __dirname + '/../node_modules/livereload-js/dist/livereload.js'
+      res.end fs.readFileSync require.resolve 'livereload-js'
   if !config.https?
     app = http.createServer requestHandler
   else

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -229,7 +229,7 @@
         res.writeHead(200, {
           'Content-Type': 'text/javascript'
         });
-        return res.end(fs.readFileSync(__dirname + '/../node_modules/livereload-js/dist/livereload.js'));
+        return res.end(fs.readFileSync(require.resolve('livereload-js')));
       }
     };
     if (config.https == null) {


### PR DESCRIPTION
This change https://github.com/napcs/node-livereload/commit/a86d5eecf9a1d6e7c879fe993486c69ef2bea123#diff-0ee60c40b899e39fed1aba1b8d9489c2R193 released in `0.9.0` broke this package for me:

```
app-livereload_1   | Starting LiveReload v0.9.0 for /code/dist on port 35729.
app-livereload_1   | internal/fs/utils.js:230
app-livereload_1   |     throw err;
app-livereload_1   |     ^
app-livereload_1   |
app-livereload_1   | Error: ENOENT: no such file or directory, open '/code/node_modules/livereload/lib/../node_modules/livereload-js/dist/livereload.js'
app-livereload_1   |     at Object.openSync (fs.js:457:3)
app-livereload_1   |     at Object.readFileSync (fs.js:359:35)
app-livereload_1   |     at Server.requestHandler (/code/node_modules/livereload/lib/livereload.js:232:27)
app-livereload_1   |     at Server.emit (events.js:321:20)
app-livereload_1   |     at parserOnIncoming (_http_server.js:780:12)
app-livereload_1   |     at HTTPParser.parserOnHeadersComplete (_http_common.js:116:17) {
app-livereload_1   |   errno: -2,
app-livereload_1   |   syscall: 'open',
app-livereload_1   |   code: 'ENOENT',
app-livereload_1   |   path: '/code/node_modules/livereload/lib/../node_modules/livereload-js/dist/livereload.js'
app-livereload_1   | }
```

It seems the path used here was not reliable for all installations. In my case, the `node_modules` folder was flattened and did not exist at `../node_modules` but at `../../node_modules`. Using `require.resolve` eliminates this issue and will always grab the correct absolute path of the `livereload.js` file.