### PR TITLE
Use require.resolve to serve livereload-js

### DIFF
--- a/lib/livereload.coffee
+++ b/lib/livereload.coffee
@@ -190,7 +190,7 @@ exports.createServer = (config = {}, callback) ->
   requestHandler = ( req, res )->
     if url.parse(req.url).pathname is '/livereload.js'
       res.writeHead(200, {'Content-Type': 'text/javascript'})
-      res.end fs.readFileSync __dirname + '/../node_modules/livereload-js/dist/livereload.js'
+      res.end fs.readFileSync require.resolve 'livereload-js'
   if !config.https?
     app = http.createServer requestHandler
   else

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -229,7 +229,7 @@
         res.writeHead(200, {
           'Content-Type': 'text/javascript'
         });
-        return res.end(fs.readFileSync(__dirname + '/../node_modules/livereload-js/dist/livereload.js'));
+        return res.end(fs.readFileSync(require.resolve('livereload-js')));
       }
     };
     if (config.https == null) {


### PR DESCRIPTION
The previous implementation depended on livereload-js being installed into the 'node_modules' directory of this project.

On more complex projects with multiple dependencies that depend on livereload-js, NPM will install livereload-js to the root node_modules directory, resulting in the[ fixed path used here](https://github.com/napcs/node-livereload/blob/master/lib/livereload.coffee#L193) to be incorrect.

Node supplies [require.resolve](https://nodejs.org/api/modules.html#modules_require_resolve_request_options) as a method to determine the location of a dependency script.  This PR replaces the[ hard-coded path](https://github.com/napcs/node-livereload/blob/master/lib/livereload.coffee#L193) with require.resolve to ensure we load the script from wherever it is installed.

This should resolve [this issue](https://github.com/napcs/node-livereload/issues/144)