### PR TITLE
Turn on CORS

### DIFF
--- a/lib/livereload.coffee
+++ b/lib/livereload.coffee
@@ -17,6 +17,13 @@ defaultExts = [
 
 defaultExclusions = [/\.git\//, /\.svn\//, /\.hg\//]
 
+defaultHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'OPTIONS, POST, GET',
+  'Access-Control-Max-Age': 2592000, // 30 days
+  'Content-Type': 'text/javascript'
+}
+
 # Server accepts a Configuration object to configure the server.
 #
 # `version`: The protocol version to use.
@@ -220,7 +227,7 @@ class Server extends EventEmitter
 exports.createServer = (config = {}, callback) ->
   requestHandler = ( req, res )->
     if url.parse(req.url).pathname is '/livereload.js'
-      res.writeHead(200, {'Content-Type': 'text/javascript'})
+      res.writeHead(200, defaultHeaders)
       res.end fs.readFileSync require.resolve 'livereload-js'
   if !config.https?
     app = http.createServer requestHandler


### PR DESCRIPTION
Most browsers won't allow connections over the "Internet" when CORS is not configured. This is a problem in Glitch, AWS, GCP, CodeSandbox and other setups where HTTPS encryption is handled by a transparent reverse proxy. Usually nginx, tiny, Apache Mod-proxy, Route 53 or Google Load Balancer.