### PR TITLE
Add option to specify host name (`host` and `-h` or `--host` respectively)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ $ livereload ~/website
 
 The commandline options are
 
-* `-p` or `--port` to specify the listening port
+* `-p` or `--port` to specify the listening port.
+* `-h` or `--host` to specify the host name to which to bind the server.
 * `-d` or `--debug` to show debug messages when the browser reloads.
 * `-e` or `--exts` to specify extentions that you want to observe. Example: ` -e 'jade,scss'`. Removes the default extensions.
 * `-ee` or `--extraExts` to include additional extentions that you want to observe. Example: ` -ee 'jade,scss'`.
@@ -146,6 +147,7 @@ The first are some configuration options, passed as a JavaScript object:
 
 * `https` is an optional object of options to be passed to [https.createServer](http://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) (if not provided, `http.createServer` is used instead)
 * `port` is the listening port. It defaults to `35729` which is what the LiveReload extensions use currently.
+* `host` is the host name to which to bind the server. It defaults to `localhost`.
 * `exts` is an array of extensions you want to observe. This overrides the default extensions of `[`html`, `css`, `js`, `png`, `gif`, `jpg`, `php`, `php5`, `py`, `rb`,  `erb`, `coffee`]`.
 * `extraExts` is an array of extensions you want to observe. The default extensions are `[`html`, `css`, `js`, `png`, `gif`, `jpg`, `php`, `php5`, `py`, `rb`,  `erb`, `coffee`]`.
 * `applyCSSLive` tells LiveReload to reload CSS files in the background instead of refreshing the page. The default for this is `true`.
@@ -229,6 +231,10 @@ Contributions welcome, but remember that this library is meant to be small and s
 When submitting code, please keep commits small, and do not modify the README file. Commit both the Coffee and JS files.
 
 # Changelog
+
+### 0.9.4
+* Server: Added `host` option to specify the host name to bind the server to.
+* CLI: Added `-h` or `--host` option to specify the host name to bind the server to.
 
 ### 0.9.3
 * CLI: Fix multiple path parsing bug.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ livereload ~/website
 The commandline options are
 
 * `-p` or `--port` to specify the listening port.
-* `-h` or `--host` to specify the host name to which to bind the server.
+* `-b` or `--bind` to specify the host name to which to bind the server.
 * `-d` or `--debug` to show debug messages when the browser reloads.
 * `-e` or `--exts` to specify extentions that you want to observe. Example: ` -e 'jade,scss'`. Removes the default extensions.
 * `-ee` or `--extraExts` to include additional extentions that you want to observe. Example: ` -ee 'jade,scss'`.
@@ -147,7 +147,7 @@ The first are some configuration options, passed as a JavaScript object:
 
 * `https` is an optional object of options to be passed to [https.createServer](http://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) (if not provided, `http.createServer` is used instead)
 * `port` is the listening port. It defaults to `35729` which is what the LiveReload extensions use currently.
-* `host` is the host name to which to bind the server. It defaults to `localhost`.
+* `bind` is the host name to which to bind the server. It defaults to `localhost`.
 * `exts` is an array of extensions you want to observe. This overrides the default extensions of `[`html`, `css`, `js`, `png`, `gif`, `jpg`, `php`, `php5`, `py`, `rb`,  `erb`, `coffee`]`.
 * `extraExts` is an array of extensions you want to observe. The default extensions are `[`html`, `css`, `js`, `png`, `gif`, `jpg`, `php`, `php5`, `py`, `rb`,  `erb`, `coffee`]`.
 * `applyCSSLive` tells LiveReload to reload CSS files in the background instead of refreshing the page. The default for this is `true`.
@@ -234,7 +234,7 @@ When submitting code, please keep commits small, and do not modify the README fi
 
 ### 0.9.4
 * Server: Added `host` option to specify the host name to bind the server to.
-* CLI: Added `-h` or `--host` option to specify the host name to bind the server to.
+* CLI: Added `-b` or `--bind` option to specify the host name to bind the server to.
 
 ### 0.9.3
 * CLI: Fix multiple path parsing bug.

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -31,6 +31,13 @@ runner = ->
       required: false
     }
     {
+      short: "h"
+      long:  "host"
+      description: "Specify the host the server should listen on."
+      value: true
+      required: false
+    }
+    {
       short: "x"
       long: "exclusions"
       description: "Exclude files from being watched by specifying an array of regular expressions. Will be appended to default value which is [/\.git\//, /\.svn\//, /\.hg\//]",
@@ -95,6 +102,7 @@ runner = ->
     .map((x)->resolve(x))
 
   port = opts.get('port') || 35729
+  host = opts.get('host') || 'localhost'
   exclusions = if opts.get('exclusions') then opts.get('exclusions' ).split(',' ).map((s) -> new RegExp(s)) else []
   exts = if opts.get('exts') then opts.get('exts').split(',').map((ext) -> ext.trim()) else  []
   extraExts = if opts.get('extraExts') then opts.get('extraExts').split(',').map((ext) -> ext.trim()) else  []
@@ -105,6 +113,7 @@ runner = ->
 
   server = livereload.createServer({
     port: port
+    host: host
     debug: debug
     exclusions: exclusions,
     exts: exts
@@ -115,7 +124,7 @@ runner = ->
     originalPath: originalPath
   })
 
-  console.log "Starting LiveReload v#{version} for #{path} on port #{port}."
+  console.log "Starting LiveReload v#{version} for #{path} on #{host}:#{port}."
 
   server.on 'error', (err) ->
     if err.code == "EADDRINUSE"

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -31,8 +31,8 @@ runner = ->
       required: false
     }
     {
-      short: "h"
-      long:  "host"
+      short: "b"
+      long:  "bind"
       description: "Specify the host the server should listen on."
       value: true
       required: false
@@ -102,7 +102,7 @@ runner = ->
     .map((x)->resolve(x))
 
   port = opts.get('port') || 35729
-  host = opts.get('host') || 'localhost'
+  host = opts.get('bind') || 'localhost'
   exclusions = if opts.get('exclusions') then opts.get('exclusions' ).split(',' ).map((s) -> new RegExp(s)) else []
   exts = if opts.get('exts') then opts.get('exts').split(',').map((ext) -> ext.trim()) else  []
   extraExts = if opts.get('extraExts') then opts.get('extraExts').split(',').map((ext) -> ext.trim()) else  []

--- a/lib/livereload.coffee
+++ b/lib/livereload.coffee
@@ -9,6 +9,7 @@ EventEmitter = require('events')
 
 protocol_version = '7'
 defaultPort = 35729
+defaultHost = 'localhost'
 
 defaultExts = [
   'html', 'css', 'js', 'png', 'gif', 'jpg',
@@ -21,6 +22,7 @@ defaultExclusions = [/\.git\//, /\.svn\//, /\.hg\//]
 #
 # `version`: The protocol version to use.
 # `port`: the LiveReload listen port
+# `host`: the LiveReload listen host
 # `exts`: the extensions to watch. An array of extensions.
 # `extraExts`: extensions in addition to the default extensions
 # `exclusions`: array of regex patterns to exclude. Default is [/\.git\//, /\.svn\//, /\.hg\//]
@@ -37,6 +39,7 @@ class Server extends EventEmitter
 
     @config.version ?= protocol_version
     @config.port    ?= defaultPort
+    @config.host    ?= defaultHost
 
     @config.exts       ?= []
     @config.extraExts  ?= []
@@ -69,10 +72,10 @@ class Server extends EventEmitter
     """
 
     if @config.server
-      @config.server.listen @config.port
+      @config.server.listen @config.port, @config.host
       @server = new ws.Server({server: @config.server})
     else
-      @server = new ws.Server({port: @config.port})
+      @server = new ws.Server({port: @config.port, host: @config.host})
 
     @server.on 'connection', @onConnection.bind @
     @server.on 'close',      @onClose.bind @


### PR DESCRIPTION
Add option to specify host name (`host` and `-h` or `--host` respectively). Resolves  #161.